### PR TITLE
Fix duplicate sync code listeners and validation

### DIFF
--- a/meds/index.html
+++ b/meds/index.html
@@ -19,7 +19,7 @@
     <!-- Add favicon -->
     <link rel="icon" type="image/png" sizes="32x32" href="imgs/favicon.png" />
   </head>
-  <body onload="initializePage()">
+  <body>
     <div class="container">
       <div class="progress-bar">
         <div class="progress"></div>
@@ -140,19 +140,5 @@
         >Clear LocalStorage</a
       >
     </div>
-    <script>
-      document
-        .getElementById("generateSyncCode")
-        .addEventListener("click", generateSyncCode);
-      console.log("clickie");
-      document.getElementById("applySyncCode").addEventListener("click", () => {
-        const code = document.getElementById("syncCodeInput").value;
-        if (code.length === SYNC_CODE_LENGTH) {
-          applySyncCode(code);
-        } else {
-          showError("Please enter a valid 6-character sync code");
-        }
-      });
-    </script>
   </body>
 </html>

--- a/meds/js/medication-timer.js
+++ b/meds/js/medication-timer.js
@@ -54,11 +54,16 @@ function initializePage() {
     .getElementById("generateSyncCode")
     .addEventListener("click", generateSyncCode);
   document.getElementById("applySyncCode").addEventListener("click", () => {
-    const code = document.getElementById("syncCodeInput").value;
-    if (code.trim().length > 0) {
+    const code = document
+      .getElementById("syncCodeInput")
+      .value.trim()
+      .toUpperCase();
+    if (code.length === SYNC_CODE_LENGTH) {
       applySyncCode(code);
     } else {
-      showError("Please enter a sync code");
+      showError(
+        `Please enter a valid ${SYNC_CODE_LENGTH}-character sync code`
+      );
     }
   });
 


### PR DESCRIPTION
## Summary
- prevent duplicate initialization by removing inline script and onload attribute
- validate sync code length before applying settings

## Testing
- `node --check meds/js/medication-timer.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e4c833a48329b2ed3d2a9895ec06