### PR TITLE
Add retro-styled terminal page

### DIFF
--- a/meds/css/retro-terminal.css
+++ b/meds/css/retro-terminal.css
@@ -1,0 +1,240 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+
+:root {
+  color-scheme: dark;
+  --crt-green: #32ff8f;
+  --crt-glow: rgba(50, 255, 143, 0.75);
+  --crt-amber: #ffc45c;
+  --scanline-alpha: 0.12;
+  --background: radial-gradient(circle at 20% 20%, #0b1d1c 0%, #02060b 60%, #000 100%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+  background: #010202;
+  font-family: 'Share Tech Mono', monospace;
+  overflow: hidden;
+}
+
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-image: var(--background);
+  color: var(--crt-green);
+}
+
+.crt {
+  position: relative;
+  width: min(1280px, 96vw);
+  height: min(720px, 92vh);
+  padding: 3rem;
+  background: rgba(5, 15, 10, 0.95);
+  border-radius: 18px;
+  box-shadow: 0 0 70px rgba(32, 255, 168, 0.3), inset 0 0 60px rgba(9, 45, 35, 0.8);
+  overflow: hidden;
+}
+
+.crt::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top center, rgba(155, 255, 195, 0.15), transparent 60%);
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.overlay {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+}
+
+.overlay--scanlines {
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, var(--scanline-alpha)) 0,
+    rgba(0, 0, 0, var(--scanline-alpha)) 2px,
+    rgba(32, 255, 143, 0.04) 2px,
+    rgba(32, 255, 143, 0.04) 4px
+  );
+  animation: scan 12s linear infinite;
+  opacity: 0.55;
+}
+
+.overlay--vignette {
+  background: radial-gradient(circle, transparent 50%, rgba(0, 0, 0, 0.65) 100%);
+}
+
+.overlay--glow {
+  background: radial-gradient(circle at center, rgba(50, 255, 143, 0.08) 0%, transparent 70%);
+  mix-blend-mode: screen;
+}
+
+@keyframes scan {
+  from {
+    transform: translateY(-4px);
+  }
+  to {
+    transform: translateY(4px);
+  }
+}
+
+.terminal {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border: 2px solid rgba(32, 255, 143, 0.35);
+  border-radius: 10px;
+  box-shadow: inset 0 0 24px rgba(8, 64, 40, 0.45);
+  overflow: hidden;
+  backdrop-filter: blur(1px);
+}
+
+.terminal__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1.4rem;
+  background: linear-gradient(90deg, rgba(4, 28, 18, 0.8) 0%, rgba(12, 50, 30, 0.65) 50%, rgba(4, 28, 18, 0.8) 100%);
+  box-shadow: inset 0 -1px 0 rgba(32, 255, 143, 0.2);
+  text-transform: uppercase;
+  letter-spacing: 0.15rem;
+  font-size: 0.8rem;
+  color: rgba(230, 255, 240, 0.6);
+}
+
+.terminal__led {
+  display: inline-block;
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 50%;
+  background: rgba(80, 120, 110, 0.8);
+  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.9);
+  position: relative;
+}
+
+.terminal__led::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.5), transparent 65%);
+}
+
+.terminal__led--red {
+  background: rgba(255, 65, 65, 0.7);
+}
+
+.terminal__led--yellow {
+  background: rgba(255, 214, 102, 0.7);
+}
+
+.terminal__led--green {
+  background: rgba(116, 255, 149, 0.7);
+}
+
+.terminal__viewport {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+  gap: 1.4rem;
+  overflow: hidden;
+}
+
+.terminal__output {
+  flex: 1;
+  overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  font-size: clamp(1rem, 1.2vw + 0.6rem, 1.35rem);
+  text-shadow: 0 0 12px var(--crt-glow), 0 0 32px rgba(32, 255, 143, 0.6);
+}
+
+.terminal__line {
+  animation: flicker 5s linear infinite;
+  filter: drop-shadow(0 0 8px rgba(32, 255, 143, 0.35));
+  letter-spacing: 0.08em;
+}
+
+.terminal__line[data-glow='pulse'] {
+  animation: flicker 5s linear infinite, pulse 3.6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    text-shadow: 0 0 10px var(--crt-glow), 0 0 24px rgba(32, 255, 143, 0.7);
+  }
+  50% {
+    text-shadow: 0 0 20px rgba(32, 255, 143, 0.9), 0 0 40px rgba(32, 255, 143, 0.6);
+  }
+}
+
+.terminal__prompt {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: clamp(1rem, 1vw + 0.75rem, 1.35rem);
+  letter-spacing: 0.1em;
+}
+
+.terminal__path {
+  color: var(--crt-amber);
+  text-shadow: 0 0 10px rgba(255, 196, 92, 0.7);
+}
+
+.terminal__cursor {
+  width: 0.8rem;
+  height: 1.4rem;
+  background: var(--crt-green);
+  box-shadow: 0 0 14px var(--crt-glow);
+  animation: blink 1.1s steps(2) infinite;
+}
+
+@keyframes blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes flicker {
+  0%,
+  19%,
+  21%,
+  23%,
+  64%,
+  100% {
+    opacity: 1;
+  }
+  20%,
+  65% {
+    opacity: 0.45;
+  }
+}
+
+@media (max-width: 768px) {
+  .crt {
+    width: 94vw;
+    height: 88vh;
+    padding: 1.5rem;
+  }
+
+  .terminal__viewport {
+    padding: 1.4rem;
+  }
+}

--- a/meds/js/retro-terminal.js
+++ b/meds/js/retro-terminal.js
@@ -1,0 +1,56 @@
+const output = document.getElementById('terminal-output');
+
+const lines = [
+  'BOOTING COOL-RETRO-TERM ...',
+  '>> MEMORY CHECK: OK',
+  '>> VIDEO SIGNAL: STABLE',
+  '>> LOADING NEON MATRIX...',
+  '>> BRINGING PHOSPHOR ONLINE',
+  '>> READY FOR USER INPUT',
+  'WELCOME BACK, OPERATOR.'
+];
+
+const createLine = text => {
+  const line = document.createElement('p');
+  line.className = 'terminal__line';
+  line.textContent = text;
+  line.setAttribute('role', 'text');
+  return line;
+};
+
+const typeLine = (text, delay = 42) =>
+  new Promise(resolve => {
+    const line = createLine('');
+    output.append(line);
+
+    let index = 0;
+    const typer = setInterval(() => {
+      line.textContent = text.slice(0, index);
+      index += 1;
+
+      if (index > text.length) {
+        clearInterval(typer);
+        resolve();
+      }
+    }, delay);
+  });
+
+const bootSequence = async () => {
+  for (const [idx, line] of lines.entries()) {
+    await typeLine(line, idx < 2 ? 28 : 42);
+    await new Promise(r => setTimeout(r, 240));
+  }
+
+  const hint = createLine('TYPE HELP FOR COMMAND LIST');
+  hint.dataset.glow = 'pulse';
+  output.append(hint);
+};
+
+const randomFlicker = () => {
+  const intensity = Math.random() * 0.25 + 0.85;
+  document.documentElement.style.setProperty('--scanline-alpha', intensity.toFixed(2));
+};
+
+setInterval(randomFlicker, 1800);
+
+bootSequence();

--- a/meds/retro-terminal.html
+++ b/meds/retro-terminal.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Retro Terminal Experience</title>
+  <link rel="stylesheet" href="css/retro-terminal.css">
+</head>
+<body>
+  <div class="crt">
+    <div class="overlay overlay--scanlines"></div>
+    <div class="overlay overlay--vignette"></div>
+    <div class="overlay overlay--glow"></div>
+    <main class="terminal" role="main" aria-live="polite">
+      <header class="terminal__header">
+        <span class="terminal__led terminal__led--red"></span>
+        <span class="terminal__led terminal__led--yellow"></span>
+        <span class="terminal__led terminal__led--green"></span>
+        <p class="terminal__title">COOL RETRO TERMINAL v1.0</p>
+      </header>
+      <section class="terminal__viewport">
+        <div class="terminal__output" id="terminal-output" aria-label="Terminal output"></div>
+        <div class="terminal__prompt">
+          <span class="terminal__path">C:\\RETRO&gt;</span>
+          <span class="terminal__cursor" aria-hidden="true"></span>
+        </div>
+      </section>
+    </main>
+  </div>
+  <script src="js/retro-terminal.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone retro terminal experience page with CRT chrome and responsive layout
- implement neon-inspired styling, scanline overlays, and accessibility-focused structure
- animate boot sequence text and ambient flicker for immersive interaction

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d906e0902c83298eaf7cd4483f746b