### PR TITLE
Relocate retro terminal assets

### DIFF
--- a/retro-terminal.html
+++ b/retro-terminal.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Retro Terminal Experience</title>
+  <link rel="stylesheet" href="retro-terminal/css/retro-terminal.css">
+</head>
+<body data-theme="green">
+  <div class="crt">
+    <div class="overlay overlay--scanlines"></div>
+    <div class="overlay overlay--vignette"></div>
+    <div class="overlay overlay--glow"></div>
+    <main class="terminal" role="main" aria-live="polite">
+      <header class="terminal__header">
+        <span class="terminal__led terminal__led--red"></span>
+        <span class="terminal__led terminal__led--yellow"></span>
+        <span class="terminal__led terminal__led--green"></span>
+        <p class="terminal__title">COOL RETRO TERMINAL v1.0</p>
+        <div class="terminal__controls" role="group" aria-label="Theme selector">
+          <button class="terminal__theme-button" type="button" data-theme="green" aria-pressed="true">
+            <span class="sr-only">Phosphor green theme</span>
+          </button>
+          <button class="terminal__theme-button" type="button" data-theme="amber" aria-pressed="false">
+            <span class="sr-only">Amber monochrome theme</span>
+          </button>
+          <button class="terminal__theme-button" type="button" data-theme="blue" aria-pressed="false">
+            <span class="sr-only">Icy blue theme</span>
+          </button>
+        </div>
+      </header>
+      <section class="terminal__viewport">
+        <div class="terminal__output" id="terminal-output" aria-label="Terminal output"></div>
+        <form class="terminal__prompt" id="terminal-form" autocomplete="off">
+          <label class="sr-only" for="terminal-input">Terminal input</label>
+          <span class="terminal__path" data-terminal-path>C:\RETRO&gt;</span>
+          <input
+            id="terminal-input"
+            class="terminal__input"
+            type="text"
+            name="terminal-input"
+            spellcheck="false"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            aria-label="Type commands here"
+          />
+        </form>
+      </section>
+    </main>
+  </div>
+  <script src="retro-terminal/js/retro-terminal.js" defer></script>
+</body>
+</html>

--- a/retro-terminal/css/retro-terminal.css
+++ b/retro-terminal/css/retro-terminal.css
@@ -1,0 +1,355 @@
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&display=swap');
+
+:root {
+  color-scheme: dark;
+  --scanline-alpha: 0.12;
+  --crt-primary: #32ff8f;
+  --crt-glow: rgba(50, 255, 143, 0.75);
+  --crt-secondary: #ffc45c;
+  --crt-background: radial-gradient(circle at 20% 20%, #0b1d1c 0%, #02060b 60%, #000 100%);
+  --crt-surface: rgba(5, 15, 10, 0.95);
+  --crt-surface-border: rgba(32, 255, 143, 0.35);
+  --crt-shadow: rgba(32, 255, 168, 0.3);
+  --crt-glass: rgba(9, 45, 35, 0.8);
+  --crt-header-start: rgba(4, 28, 18, 0.8);
+  --crt-header-mid: rgba(12, 50, 30, 0.65);
+  --crt-header-text: rgba(230, 255, 240, 0.6);
+  --crt-header-shadow: rgba(50, 255, 143, 0.2);
+  --crt-scanline-glow: rgba(32, 255, 143, 0.04);
+  --crt-ambient-glow: rgba(50, 255, 143, 0.08);
+}
+
+body[data-theme='amber'] {
+  --crt-primary: #ffc45c;
+  --crt-glow: rgba(255, 196, 92, 0.7);
+  --crt-secondary: #ffefb0;
+  --crt-background: radial-gradient(circle at 20% 20%, #2a1a05 0%, #0b0601 65%, #000 100%);
+  --crt-surface: rgba(35, 20, 5, 0.94);
+  --crt-surface-border: rgba(255, 196, 92, 0.32);
+  --crt-shadow: rgba(255, 168, 92, 0.25);
+  --crt-glass: rgba(60, 36, 9, 0.7);
+  --crt-header-start: rgba(45, 28, 12, 0.9);
+  --crt-header-mid: rgba(92, 55, 16, 0.7);
+  --crt-header-text: rgba(255, 241, 220, 0.7);
+  --crt-header-shadow: rgba(255, 196, 92, 0.2);
+  --crt-scanline-glow: rgba(255, 196, 92, 0.04);
+  --crt-ambient-glow: rgba(255, 196, 92, 0.08);
+}
+
+body[data-theme='blue'] {
+  --crt-primary: #5ad4ff;
+  --crt-glow: rgba(90, 212, 255, 0.7);
+  --crt-secondary: #a6f1ff;
+  --crt-background: radial-gradient(circle at 20% 20%, #0a1d2b 0%, #02060b 60%, #000 100%);
+  --crt-surface: rgba(5, 18, 28, 0.94);
+  --crt-surface-border: rgba(90, 212, 255, 0.3);
+  --crt-shadow: rgba(90, 212, 255, 0.27);
+  --crt-glass: rgba(10, 45, 60, 0.75);
+  --crt-header-start: rgba(10, 28, 45, 0.85);
+  --crt-header-mid: rgba(26, 64, 92, 0.65);
+  --crt-header-text: rgba(216, 239, 255, 0.7);
+  --crt-header-shadow: rgba(90, 212, 255, 0.2);
+  --crt-scanline-glow: rgba(90, 212, 255, 0.04);
+  --crt-ambient-glow: rgba(90, 212, 255, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+  background: #010202;
+  font-family: 'IBM Plex Mono', monospace;
+  overflow: hidden;
+}
+
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-image: var(--crt-background);
+  color: var(--crt-primary);
+}
+
+.crt {
+  position: relative;
+  width: min(1280px, 96vw);
+  height: min(720px, 92vh);
+  padding: 3rem;
+  background: var(--crt-surface);
+  border-radius: 18px;
+  box-shadow: 0 0 70px var(--crt-shadow), inset 0 0 60px var(--crt-glass);
+  overflow: hidden;
+}
+
+.crt::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top center, rgba(155, 255, 195, 0.15), transparent 60%);
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.overlay {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+}
+
+.overlay--scanlines {
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, var(--scanline-alpha)) 0,
+    rgba(0, 0, 0, var(--scanline-alpha)) 2px,
+    var(--crt-scanline-glow) 2px,
+    var(--crt-scanline-glow) 4px
+  );
+  animation: scan 12s linear infinite;
+  opacity: 0.55;
+}
+
+.overlay--vignette {
+  background: radial-gradient(circle, transparent 50%, rgba(0, 0, 0, 0.65) 100%);
+}
+
+.overlay--glow {
+  background: radial-gradient(circle at center, var(--crt-ambient-glow) 0%, transparent 70%);
+  mix-blend-mode: screen;
+}
+
+@keyframes scan {
+  from {
+    transform: translateY(-4px);
+  }
+  to {
+    transform: translateY(4px);
+  }
+}
+
+.terminal {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border: 2px solid var(--crt-surface-border);
+  border-radius: 10px;
+  box-shadow: inset 0 0 24px rgba(8, 64, 40, 0.45);
+  overflow: hidden;
+  backdrop-filter: blur(1px);
+}
+
+.terminal__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1.4rem;
+  background: linear-gradient(90deg, var(--crt-header-start) 0%, var(--crt-header-mid) 50%, var(--crt-header-start) 100%);
+  box-shadow: inset 0 -1px 0 var(--crt-header-shadow);
+  text-transform: uppercase;
+  letter-spacing: 0.15rem;
+  font-size: 0.8rem;
+  color: var(--crt-header-text);
+}
+
+.terminal__led {
+  display: inline-block;
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 50%;
+  background: rgba(80, 120, 110, 0.8);
+  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.9);
+  position: relative;
+}
+
+.terminal__led::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.5), transparent 65%);
+}
+
+.terminal__led--red {
+  background: rgba(255, 65, 65, 0.7);
+}
+
+.terminal__led--yellow {
+  background: rgba(255, 214, 102, 0.7);
+}
+
+.terminal__led--green {
+  background: rgba(116, 255, 149, 0.7);
+}
+
+.terminal__viewport {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+  gap: 1.2rem;
+  overflow: hidden;
+}
+
+.terminal__output {
+  flex: 1;
+  overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-size: clamp(0.95rem, 1.1vw + 0.55rem, 1.25rem);
+  text-shadow: 0 0 12px var(--crt-glow), 0 0 32px var(--crt-primary);
+  line-height: 1.2;
+}
+
+.terminal__line {
+  animation: flicker 5s linear infinite;
+  filter: drop-shadow(0 0 8px var(--crt-primary));
+  letter-spacing: 0.04em;
+}
+
+.terminal__line[data-glow='pulse'] {
+  animation: flicker 5s linear infinite, pulse 3.6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    text-shadow: 0 0 10px var(--crt-glow), 0 0 24px var(--crt-primary);
+  }
+  50% {
+    text-shadow: 0 0 20px var(--crt-primary), 0 0 40px var(--crt-primary);
+  }
+}
+
+.terminal__prompt {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  font-size: clamp(0.95rem, 1vw + 0.7rem, 1.25rem);
+  letter-spacing: 0.06em;
+  margin-top: auto;
+}
+
+.terminal__path {
+  color: var(--crt-secondary);
+  text-shadow: 0 0 10px var(--crt-glow);
+  white-space: nowrap;
+}
+
+.terminal__input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--crt-primary);
+  font: inherit;
+  letter-spacing: inherit;
+  caret-color: var(--crt-secondary);
+  text-shadow: 0 0 12px var(--crt-glow);
+  outline: none;
+  padding: 0;
+  min-width: 0;
+}
+
+.terminal__input::selection {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.terminal__controls {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.terminal__theme-button {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(0, 0, 0, 0.35);
+  color: inherit;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  position: relative;
+  cursor: pointer;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.45);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+}
+
+.terminal__theme-button::after {
+  content: '';
+  position: absolute;
+  inset: 0.25rem;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 10px currentColor;
+}
+
+.terminal__theme-button:focus-visible {
+  outline: 2px solid var(--crt-secondary);
+  outline-offset: 2px;
+}
+
+.terminal__theme-button[data-theme='green'] {
+  color: #32ff8f;
+}
+
+.terminal__theme-button[data-theme='amber'] {
+  color: #ffc45c;
+}
+
+.terminal__theme-button[data-theme='blue'] {
+  color: #5ad4ff;
+}
+
+.terminal__theme-button[aria-pressed='true'] {
+  transform: scale(1.05);
+  border-color: currentColor;
+  box-shadow: 0 0 16px currentColor;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes flicker {
+  0%,
+  19%,
+  21%,
+  23%,
+  64%,
+  100% {
+    opacity: 1;
+  }
+  20%,
+  65% {
+    opacity: 0.45;
+  }
+}
+
+@media (max-width: 768px) {
+  .crt {
+    width: 94vw;
+    height: 88vh;
+    padding: 1.5rem;
+  }
+
+  .terminal__viewport {
+    padding: 1.2rem;
+  }
+
+  .terminal__header {
+    padding-inline: 1rem;
+  }
+}

--- a/retro-terminal/js/retro-terminal.js
+++ b/retro-terminal/js/retro-terminal.js
@@ -1,0 +1,173 @@
+const output = document.getElementById('terminal-output');
+const form = document.getElementById('terminal-form');
+const input = document.getElementById('terminal-input');
+const terminal = document.querySelector('.terminal');
+const themeButtons = document.querySelectorAll('.terminal__theme-button');
+const pathElement = document.querySelector('[data-terminal-path]');
+
+const promptPrefix = pathElement ? pathElement.textContent.trim() : 'C:\\RETRO>';
+const themes = new Set(['green', 'amber', 'blue']);
+
+const bootLines = [
+  'BOOTING COOL-RETRO-TERM ...',
+  '>> MEMORY CHECK: OK',
+  '>> VIDEO SIGNAL: STABLE',
+  '>> LOADING NEON MATRIX...',
+  '>> BRINGING PHOSPHOR ONLINE',
+  '>> READY FOR USER INPUT',
+  'WELCOME BACK, OPERATOR.'
+];
+
+const createLine = (text, glow) => {
+  const line = document.createElement('p');
+  line.className = 'terminal__line';
+  line.textContent = text;
+  line.setAttribute('role', 'text');
+  if (glow) {
+    line.dataset.glow = glow;
+  }
+  return line;
+};
+
+const appendLine = (text, glow) => {
+  const line = createLine(text, glow);
+  output.append(line);
+  output.scrollTop = output.scrollHeight;
+  return line;
+};
+
+const typeLine = (text, delay = 42) =>
+  new Promise(resolve => {
+    const line = appendLine('');
+    let index = 0;
+
+    const typer = setInterval(() => {
+      line.textContent = text.slice(0, index);
+      index += 1;
+
+      if (index > text.length) {
+        clearInterval(typer);
+        resolve();
+      }
+    }, delay);
+  });
+
+const bootSequence = async () => {
+  for (const [idx, line] of bootLines.entries()) {
+    await typeLine(line, idx < 2 ? 28 : 42);
+    await new Promise(r => setTimeout(r, 220));
+  }
+
+  appendLine('TYPE HELP FOR COMMAND LIST', 'pulse');
+};
+
+const randomFlicker = () => {
+  const intensity = Math.random() * 0.25 + 0.85;
+  document.documentElement.style.setProperty('--scanline-alpha', intensity.toFixed(2));
+};
+
+const setTheme = theme => {
+  if (!themes.has(theme)) {
+    return;
+  }
+
+  document.body.dataset.theme = theme;
+  themeButtons.forEach(button => {
+    const isActive = button.dataset.theme === theme;
+    button.setAttribute('aria-pressed', isActive.toString());
+  });
+};
+
+const printHelp = () => {
+  const helpLines = [
+    'AVAILABLE COMMANDS:',
+    'HELP  .............. SHOW THIS LIST',
+    'THEME <COLOR> ...... SWITCH PHOSPHOR (GREEN/AMBER/BLUE)',
+    'CLS   .............. CLEAR THE SCREEN',
+    'ABOUT .............. TERMINAL DETAILS'
+  ];
+  helpLines.forEach(line => appendLine(line));
+};
+
+const printAbout = () => {
+  appendLine('COOL RETRO TERMINAL v1.0');
+  appendLine('SIMULATING CRT EXPERIENCE WITH AMBIENT FLICKER');
+  appendLine('FONT: IBM PLEX MONO');
+};
+
+const handleThemeCommand = arg => {
+  const nextTheme = arg?.toLowerCase();
+  if (!nextTheme || !themes.has(nextTheme)) {
+    appendLine('USAGE: THEME GREEN | THEME AMBER | THEME BLUE');
+    return;
+  }
+
+  setTheme(nextTheme);
+  appendLine(`THEME SET TO ${nextTheme.toUpperCase()}`);
+};
+
+const handleCommand = value => {
+  const [command, ...rest] = value.trim().split(/\s+/);
+  const upperCommand = command.toUpperCase();
+  const arg = rest.join(' ');
+
+  switch (upperCommand) {
+    case 'HELP':
+      printHelp();
+      break;
+    case 'CLS':
+      output.innerHTML = '';
+      appendLine('TYPE HELP FOR COMMAND LIST', 'pulse');
+      break;
+    case 'ABOUT':
+      printAbout();
+      break;
+    case 'THEME':
+      handleThemeCommand(arg);
+      break;
+    case '':
+      break;
+    default:
+      appendLine(`UNKNOWN COMMAND: ${upperCommand}`);
+  }
+};
+
+if (form && input) {
+  form.addEventListener('submit', event => {
+    event.preventDefault();
+    const value = input.value;
+    if (!value.trim()) {
+      return;
+    }
+
+    appendLine(`${promptPrefix} ${value}`);
+    handleCommand(value);
+    input.value = '';
+    input.focus();
+  });
+}
+
+themeButtons.forEach(button => {
+  button.addEventListener('click', event => {
+    event.stopPropagation();
+    setTheme(button.dataset.theme);
+  });
+});
+
+setTheme(document.body.dataset.theme || 'green');
+
+if (terminal && input) {
+  terminal.addEventListener('click', () => {
+    input.focus();
+  });
+}
+
+window.addEventListener('load', () => {
+  if (input) {
+    input.focus();
+  }
+});
+
+setInterval(randomFlicker, 1800);
+
+bootSequence();


### PR DESCRIPTION
## Summary
- move the retro terminal page to the repository root so it can live alongside the medication tracker without path conflicts
- relocate the terminal CSS and JS into a dedicated retro-terminal/ directory and update the HTML to load from the new paths

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d906e0902c83298eaf7cd4483f746b